### PR TITLE
This removes the following old hiredis function aliases, use the new …

### DIFF
--- a/phpiredis.c
+++ b/phpiredis.c
@@ -50,7 +50,7 @@ void php_redis_reader_dtor(zend_rsrc_list_entry *rsrc TSRMLS_DC)
         }
 
         if (_reader->reader != NULL) {
-            redisReplyReaderFree(_reader->reader);
+            redisReaderFree(_reader->reader);
         }
 
         if (_reader->error_callback != NULL) {
@@ -593,7 +593,7 @@ void convert_redis_to_php(phpiredis_reader* reader, zval* return_value, redisRep
 PHP_FUNCTION(phpiredis_reader_create)
 {
     phpiredis_reader* reader = emalloc(sizeof(phpiredis_reader));
-    reader->reader = redisReplyReaderCreate();
+    reader->reader = redisReaderCreate();
     reader->error = NULL;
     reader->bufferedReply = NULL;
     reader->status_callback = NULL;
@@ -685,10 +685,10 @@ PHP_FUNCTION(phpiredis_reader_reset)
     }
 
     if (reader->reader != NULL) {
-        redisReplyReaderFree(reader->reader);
+        redisReaderFree(reader->reader);
     }
 
-    reader->reader = redisReplyReaderCreate();
+    reader->reader = redisReaderCreate();
 }
 
 
@@ -719,7 +719,7 @@ PHP_FUNCTION(phpiredis_reader_feed)
     }
 
     ZEND_FETCH_RESOURCE(reader, void *, &ptr, -1, PHPIREDIS_READER_NAME, le_redis_reader_context);
-    redisReplyReaderFeed(reader->reader, bytes, size);
+    redisReaderFeed(reader->reader, bytes, size);
 }
 
 PHP_FUNCTION(phpiredis_reader_get_error)
@@ -758,11 +758,11 @@ PHP_FUNCTION(phpiredis_reader_get_reply)
         aux = reader->bufferedReply;
         reader->bufferedReply = NULL;
     } else {
-        if (redisReplyReaderGetReply(reader->reader, &aux) == REDIS_ERR) {
+        if (redisReaderGetReply(reader->reader, &aux) == REDIS_ERR) {
             if (reader->error != NULL) {
                 efree(reader->error);
             }
-            reader->error = redisReplyReaderGetError(reader->reader);
+            reader->error = redisReaderGetError(reader->reader);
 
             RETURN_FALSE; // error
         } else if (aux == NULL) {
@@ -795,11 +795,11 @@ PHP_FUNCTION(phpiredis_reader_get_state)
     if (reader->error == NULL && reader->bufferedReply == NULL) {
         void *aux;
 
-        if (redisReplyReaderGetReply(reader->reader, &aux) == REDIS_ERR) {
+        if (redisReaderGetReply(reader->reader, &aux) == REDIS_ERR) {
             if (reader->error != NULL) {
                 efree(reader->error);
             }
-            reader->error = redisReplyReaderGetError(reader->reader);
+            reader->error = redisReaderGetError(reader->reader);
         } else {
             reader->bufferedReply = aux;
         }


### PR DESCRIPTION
…name now:

redisReplyReaderCreate	=> redisReaderCreate
redisReplyReaderCreate	=> redisReaderCreate
redisReplyReaderFree	=> redisReaderFree
redisReplyReaderFeed	=> redisReaderFeed
redisReplyReaderGetReply	=> redisReaderGetReply
redisReplyReaderSetPrivdata	=> redisReaderSetPrivdata
redisReplyReaderGetObject	=> redisReaderGetObject
redisReplyReaderGetError	=> redisReaderGetError